### PR TITLE
CP-99: Add unit testing to the global library

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+name: CI Build
+on: [push]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v1
+
+    - name: composer install
+      run: |
+        composer install
+
+    - name: composer test
+      run: |
+        composer test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor
+composer.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 composer.lock
+*.cache

--- a/README.md
+++ b/README.md
@@ -16,3 +16,12 @@ Returns an array with personalization data.
 
 ### returnVaryHeader($key)
 Returns vary header array, based on header data.
+
+## Development
+
+[PHPUnit](https://phpunit.de/) is used to run the [tests](tests).
+
+``` bash
+composer install
+composer test
+```

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "test": "phpunit tests"
+    "test": "vendor/bin/phpunit tests"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,12 @@
       "Pantheon\\EI\\": "src"
     }
   },
+  "scripts": {
+    "test": "phpunit tests"
+  },
   "minimum-stability": "dev",
-  "prefer-stable": true
+  "prefer-stable": true,
+  "require-dev": {
+    "phpunit/phpunit": "^9.5"
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "test": "vendor/bin/phpunit tests"
+    "test": "vendor/bin/phpunit -c phpunit.xml"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="tests/config/bootstrap.php">
+<phpunit>
 	<testsuites>
-		<testsuite name="WP Unit Tests">
+		<testsuite name="Pantheon Edge Integrations Unit Tests">
 			<directory>./tests/</directory>
 		</testsuite>
 	</testsuites>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/config/bootstrap.php">
+	<testsuites>
+		<testsuite name="WP Unit Tests">
+			<directory>./tests/</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/src/HeaderData.php
+++ b/src/HeaderData.php
@@ -18,17 +18,30 @@ class HeaderData {
 
   /**
    * Constructor.
+   *
+   * @param array $headerData (optional)
+   *   The input header data. If not provided, will default to $_SERVER.
+   *
+   * @see https://www.php.net/manual/en/reserved.variables.server.php
    */
-  public function __construct() {
-    $this->headers = $this->getRequestHeaders();
+  public function __construct(array $headerData = null) {
+    $this->headers = $this->getRequestHeaders($headerData);
   }
 
   /**
    * Retrieve header data and set in $headers array.
+   *
+   * @param array $headerData (optional)
+   *   The input header data. If not provided, will default to $_SERVER.
+   *
+   * @see https://www.php.net/manual/en/reserved.variables.server.php
    */
-  private function getRequestHeaders(): array {
+  private function getRequestHeaders(array $headerData = null): array {
+    if (is_null($headerData)) {
+      $headerData = $_SERVER;
+    }
     $headers = [];
-    foreach ($_SERVER as $key => $value) {
+    foreach ($headerData as $key => $value) {
       if (substr($key, 0, 5) <> 'HTTP_') {
         continue;
       }

--- a/tests/HeaderDataTest.php
+++ b/tests/HeaderDataTest.php
@@ -75,7 +75,7 @@ final class HeaderDataTest extends TestCase
 
   public function testReturnPersonalizationObject(): void {
     $input = [
-      'HTTP_AUDIENCE' => 'Parents|Children',
+      'HTTP_AUDIENCE' => 'geo:US',
       'HTTP_ROLE' => 'Administrator',
       'HTTP_INTEREST' => 'Carl Sagan|Richard Feynman',
       'HTTP_IGNORED' => 'HTTP Ignored Entry',
@@ -84,9 +84,7 @@ final class HeaderDataTest extends TestCase
     $headerData = new HeaderData($input);
     $result = $headerData->returnPersonalizationObject();
 
-    $this->assertIsArray($result['Audience']);
-    $this->assertIsArray($result['Audience']['Audience']);
-    $this->assertEquals($result['Audience']['Audience'], ['Parents', 'Children']);
+    $this->assertEquals($result['Audience']['geo'], 'US');
     $this->assertEquals($result['Role'], 'Administrator');
     $this->assertNull($result['Ignored']);
   }

--- a/tests/HeaderDataTest.php
+++ b/tests/HeaderDataTest.php
@@ -86,7 +86,7 @@ final class HeaderDataTest extends TestCase
 
     $this->assertEquals($result['Audience']['geo'], 'US');
     $this->assertEquals($result['Role'], 'Administrator');
-    $this->assertNull($result['Ignored']);
+    $this->assertArrayNotHasKey('Ignored', $result);
   }
 
   public function testReturnVaryHeader(): void {

--- a/tests/HeaderDataTest.php
+++ b/tests/HeaderDataTest.php
@@ -53,7 +53,7 @@ final class HeaderDataTest extends TestCase
 
     // Audience
     $audience = $headerData->parseHeader('Audience');
-    $this->assertIsArray($audience['Audience']); // TODO: The Audience is nested. Intended?
+    $this->assertIsArray($audience['Audience']);
     $this->assertEquals($audience['Audience'][1], 'Children');
     $this->assertEquals($audience['Name'], 'AnnaMykhailova'); // Take the last entry.
     $this->assertEquals($audience['Age'], 47);

--- a/tests/HeaderDataTest.php
+++ b/tests/HeaderDataTest.php
@@ -11,6 +11,11 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 use Pantheon\EI\HeaderData;
 
+/**
+ * Tests all the public functions within the HeaderData class.
+ *
+ * @see Pantheon\EI\HeaderData
+ */
 final class HeaderDataTest extends TestCase
 {
   /**

--- a/tests/HeaderDataTest.php
+++ b/tests/HeaderDataTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use Pantheon\EI\HeaderData;
+
+final class HeaderDataTest extends TestCase
+{
+  public function testConstructor(): void {
+    // Empty Constructor.
+    $headerData = new HeaderData();
+    $this->assertIsObject($headerData);
+
+    // Empty header data.
+    $headerData = new HeaderData([]);
+    $this->assertIsObject($headerData);
+
+    // Constructor with a small amount of array data.
+    $inputArray = [
+        'testConstructor' => 'constructor'
+    ];
+    $headerData = new HeaderData($inputArray);
+    $this->assertIsObject($headerData);
+  }
+
+  public function testGetHeader(): void {
+    $input = [
+      'HTTP_SHOULD_BE_FOUND' => 'Should be found',
+      'SERVER_NAME' => 'Entries without http_ should be ignored',
+      'HTTP_USER_AGENT' => 'Should become User_Agent'
+    ];
+    $headerData = new HeaderData($input);
+
+    $this->assertEquals($headerData->getHeader('Should-Be-Found'), 'Should be found');
+    $this->assertEmpty($headerData->getHeader('Server-Name'), 'SERVER_NAME should be ignored');
+    $this->assertEquals($headerData->getHeader('User-Agent'), 'Should become User_Agent');
+  }
+
+  public function testParseHeader(): void {
+    $input = [
+      'HTTP_AUDIENCE' => 'Parents|Children||Age:47|Name:RobLoach|Name:StevePersch|Name:AnnaMykhailova',
+      'HTTP_USER_AGENT' => 'Should just return the value',
+      'IGNORED TEST' => 'Should return an empty array',
+      'HTTP_INTEREST' => 'Carl Sagan|Richard Feynman||For Science!|With%20A Percent20',
+    ];
+    $headerData = new HeaderData($input);
+
+    // When a header doesn't exist.
+    $keyNotFound = $headerData->parseHeader('header key not found');
+    $this->assertEmpty($keyNotFound, 'Expected to return an empty array');
+    $this->assertIsArray($keyNotFound, 'Should be an array');
+
+    // Audience
+    $audience = $headerData->parseHeader('Audience');
+    $this->assertIsArray($audience['Audience']); // TODO: The Audience is nested. Intended?
+    $this->assertEquals($audience['Audience'][1], 'Children');
+    $this->assertEquals($audience['Name'], 'AnnaMykhailova'); // Take the last entry.
+    $this->assertEquals($audience['Age'], 47);
+
+    // Interest
+    $interest = $headerData->parseHeader('Interest');
+    $expected = [
+      'Carl Sagan',
+      'Richard Feynman',
+      '',
+      'For Science!',
+      'With A Percent20'
+    ];
+    $this->assertEquals($interest, $expected);
+
+    // User Agent
+    $this->assertEquals($headerData->parseHeader('User-Agent'), 'Should just return the value');
+  }
+
+  public function testReturnPersonalizationObject(): void {
+    $input = [
+      'HTTP_AUDIENCE' => 'Parents|Children',
+      'HTTP_ROLE' => 'Administrator',
+      'HTTP_INTEREST' => 'Carl Sagan|Richard Feynman',
+      'HTTP_IGNORED' => 'HTTP Ignored Entry',
+      'IGNORED_ENTRY' => 'Completely ignored entry'
+    ];
+    $headerData = new HeaderData($input);
+    $result = $headerData->returnPersonalizationObject();
+
+    $this->assertIsArray($result['Audience']);
+    $this->assertIsArray($result['Audience']['Audience']);
+    $this->assertEquals($result['Audience']['Audience'], ['Parents', 'Children']);
+    $this->assertEquals($result['Role'], 'Administrator');
+    $this->assertNull($result['Ignored']);
+  }
+
+  public function testReturnVaryHeader(): void {
+    // Without a Vary Header
+    $headerData = new HeaderData([
+      'HTTP_IGNORED' => 'Nothing'
+    ]);
+    $result = $headerData->returnVaryHeader('Vary Header');
+    $this->assertIsArray($result['vary']);
+    $this->assertArrayHasKey(0, $result['vary']);
+    $this->assertEquals($result['vary'][0], 'Vary Header');
+
+    // Valid VARY input
+    $headerData = new HeaderData([
+      'HTTP_VARY' => 'Something, Wicked, This, Way'
+    ]);
+
+    $result = $headerData->returnVaryHeader('Comes');
+    $this->assertEquals($result['vary'], ['Something', 'Wicked', 'This', 'Way', 'Comes']);
+
+    $result = $headerData->returnVaryHeader(['Author' => 'Ray Bradbury']);
+    $this->assertEquals($result['vary']['Author'], 'Ray Bradbury');
+  }
+}
+

--- a/tests/HeaderDataTest.php
+++ b/tests/HeaderDataTest.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * @file PHPUnit tests for Pantheon Edge Integrations' HeaderData class.
+ *
+ * @see Pantheon\EI\HeaderData
+ */
+
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
@@ -7,6 +13,13 @@ use Pantheon\EI\HeaderData;
 
 final class HeaderDataTest extends TestCase
 {
+  /**
+   * Tests the HeaderData constructor.
+   *
+   * @see Pantheon\EI\HeaderData::HeaderData()
+   *
+   * @group headerdata
+   */
   public function testConstructor(): void {
     // Empty Constructor.
     $headerData = new HeaderData();
@@ -24,6 +37,11 @@ final class HeaderDataTest extends TestCase
     $this->assertIsObject($headerData);
   }
 
+  /**
+   * Tests HeaderData's getHeader() method.
+   *
+   * @group headerdata
+   */
   public function testGetHeader(): void {
     $input = [
       'HTTP_SHOULD_BE_FOUND' => 'Should be found',
@@ -37,7 +55,13 @@ final class HeaderDataTest extends TestCase
     $this->assertEquals($headerData->getHeader('User-Agent'), 'Should become User_Agent');
   }
 
+  /**
+   * Tests HeaderData's parseHeader() method, which has a focus on HTTP_AUDIENCE and HTTP_INTEREST.
+   *
+   * @group headerdata
+   */
   public function testParseHeader(): void {
+    // The Audience and Interest entries are parsed into arrays.
     $input = [
       'HTTP_AUDIENCE' => 'Parents|Children||Age:47|Name:RobLoach|Name:StevePersch|Name:AnnaMykhailova',
       'HTTP_USER_AGENT' => 'Should just return the value',
@@ -73,6 +97,11 @@ final class HeaderDataTest extends TestCase
     $this->assertEquals($headerData->parseHeader('User-Agent'), 'Should just return the value');
   }
 
+  /**
+   * Tests HeaderData's returnPersonalizationObject() method.
+   *
+   * @group headerdata
+   */
   public function testReturnPersonalizationObject(): void {
     $input = [
       'HTTP_AUDIENCE' => 'geo:US',
@@ -89,6 +118,11 @@ final class HeaderDataTest extends TestCase
     $this->assertArrayNotHasKey('Ignored', $result);
   }
 
+  /**
+   * Tests HeaderData's returnVaryHeader() method.
+   *
+   * @group headerdata
+   */
   public function testReturnVaryHeader(): void {
     // Without a Vary Header
     $headerData = new HeaderData([


### PR DESCRIPTION
In order to allow testing, we had to change the API a bit to allow passing an optional input array of mock header data.