### PR TITLE
CP-97 Add the global static singleton functions API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ Returns an array with personalization data.
 ### returnVaryHeader($key)
 Returns vary header array, based on header data.
 
+## Global Methods
+
+There are a set of global functions that mirror the object methods, allowing using the API through a singleton global instance rather than having to instantiate it locally. These functions are as follows...
+
+``` php
+HeaderData::header($key);
+HeaderData::parse($key);
+HeaderData::personalizationObject();
+HeaderData::varyHeader($key);
+```
+
 ## Development
 
 [PHPUnit](https://phpunit.de/) is used to run the [tests](tests).

--- a/README.md
+++ b/README.md
@@ -17,17 +17,6 @@ Returns an array with personalization data.
 ### returnVaryHeader($key)
 Returns vary header array, based on header data.
 
-## Global Methods
-
-There are a set of global functions that mirror the object methods, allowing using the API through a singleton global instance rather than having to instantiate it locally. These functions are as follows...
-
-``` php
-HeaderData::header($key, array $data = null);
-HeaderData::parse($key, array $data = null);
-HeaderData::personalizationObject(array $data = null);
-HeaderData::varyHeader($key, array $data = null);
-```
-
 ## Development
 
 [PHPUnit](https://phpunit.de/) is used to run the [tests](tests).

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ Returns vary header array, based on header data.
 There are a set of global functions that mirror the object methods, allowing using the API through a singleton global instance rather than having to instantiate it locally. These functions are as follows...
 
 ``` php
-HeaderData::header($key);
-HeaderData::parse($key);
-HeaderData::personalizationObject();
-HeaderData::varyHeader($key);
+HeaderData::header($key, array $data = null);
+HeaderData::parse($key, array $data = null);
+HeaderData::personalizationObject(array $data = null);
+HeaderData::varyHeader($key, array $data = null);
 ```
 
 ## Development

--- a/src/HeaderData.php
+++ b/src/HeaderData.php
@@ -194,9 +194,9 @@ class HeaderData {
      *
      * @see getHeader()
      */
-      public static function header($key, array $data = null) {
-          return (new HeaderData($data))->getHeader($key);
-      }
+    public static function header($key, array $data = null) {
+        return (new HeaderData($data))->getHeader($key);
+    }
 
     /**
      * Parses a global header by key using a specified regex.
@@ -214,9 +214,9 @@ class HeaderData {
      *
      * @see parseHeader()
      */
-      public static function parse($key, array $data = null) {
-          return (new HeaderData($data))->parseHeader($key);
-      }
+    public static function parse($key, array $data = null) {
+        return (new HeaderData($data))->parseHeader($key);
+    }
 
     /**
      * Gets the global personalizaition object.
@@ -231,9 +231,9 @@ class HeaderData {
      *
      * @see returnPersonalizedObject()
      */
-      public static function personalizationObject(array $data = null) {
-          return (new HeaderData($data))->returnPersonalizationObject();
-      }
+    public static function personalizationObject(array $data = null) {
+        return (new HeaderData($data))->returnPersonalizationObject();
+    }
 
     /**
      * Returns vary header array based on the global data.
@@ -251,7 +251,7 @@ class HeaderData {
      *
      * @see returnVaryHeader()
      */
-      public static function varyHeader($key, array $data = null): array {
-          return (new HeaderData($data))->returnVaryHeader($key);
-      }
+    public static function varyHeader($key, array $data = null): array {
+        return (new HeaderData($data))->returnVaryHeader($key);
+    }
 }

--- a/src/HeaderData.php
+++ b/src/HeaderData.php
@@ -188,6 +188,9 @@ class HeaderData {
    * @param array $data (optional)
    *   The header data to parse. Defaults to $_SERVER.
    *
+   * Example:
+   *     Pantheon\EI\HeaderData::header('Audience');
+   *
    * @return string
    *   Returns header value.
    *
@@ -204,6 +207,9 @@ class HeaderData {
    *   Key for the header.
    * @param array $data (optional)
    *   The header data to parse. Defaults to $_SERVER.
+   *
+   * Example:
+   *     Pantheon\EI\HeaderData::parse('Audience');
    *
    * @return array|string
    *   Returns important parts of header string.
@@ -222,6 +228,9 @@ class HeaderData {
    * @param array $data (optional)
    *   The header data to parse. Defaults to $_SERVER.
    *
+   * Example:
+   *     Pantheon\EI\HeaderData::personalizationObject();
+   *
    * @see returnPersonalizedObject()
    */
   public static function personalizationObject(array $data = null) {
@@ -235,6 +244,9 @@ class HeaderData {
    *   Key for the header, or array of keys.
    * @param array $data (optional)
    *   The header data to parse. Defaults to $_SERVER.
+   *
+   * Example:
+   *     Pantheon\EI\HeaderData::varyHeader('geo');
    *
    * @return array
    *   Vary header array, based on header data.

--- a/src/HeaderData.php
+++ b/src/HeaderData.php
@@ -17,13 +17,6 @@ class HeaderData {
   private $headers;
 
   /**
-   * The static header data used for the global function calls.
-   *
-   * @var headerData
-   */
-  private static $headerData;
-
-  /**
    * Constructor.
    *
    * @param array $headerData (optional)
@@ -188,39 +181,20 @@ class HeaderData {
   }
 
   /**
-   * Get the singleton instance for the global functions API.
-   */
-  private static function getInstance(): HeaderData {
-    if (self::$headerData == null) {
-      self::$headerData = new HeaderData();
-    }
- 
-    return self::$headerData;
-  }
-
-  /**
-   * Sets the given header data associated with the global functions.
-   * 
-   * @param $data array (optional)
-   *   The array data to set when reading header data. Defaults to $_SERVER.
-   */
-  public static function setHeaderData(array $data = null): void {
-    self::$headerData = new HeaderData($data);
-  }
-
-  /**
    * Gets the global header data based on the given key.
    *
    * @param string $key
    *   Key for the header.
+   * @param array $data (optional)
+   *   The header data to parse. Defaults to $_SERVER.
    *
    * @return string
    *   Returns header value.
    *
    * @see getHeader()
    */
-  public static function header($key) {
-    return self::getInstance()->getHeader($key);
+  public static function header($key, array $data = null) {
+    return (new HeaderData($data))->getHeader($key);
   }
 
   /**
@@ -228,14 +202,16 @@ class HeaderData {
    *
    * @param string $key
    *   Key for the header.
+   * @param array $data (optional)
+   *   The header data to parse. Defaults to $_SERVER.
    *
    * @return array|string
    *   Returns important parts of header string.
    *
    * @see parseHeader()
    */
-  public static function parse($key) {
-    return self::getInstance()->parseHeader($key);
+  public static function parse($key, array $data = null) {
+    return (new HeaderData($data))->parseHeader($key);
   }
 
   /**
@@ -243,11 +219,13 @@ class HeaderData {
    *
    * @return array
    *   Returns object with data used for personalization.
-   * 
+   * @param array $data (optional)
+   *   The header data to parse. Defaults to $_SERVER.
+   *
    * @see returnPersonalizedObject()
    */
-  public static function personalizationObject() {
-    return self::getInstance()->returnPersonalizationObject();
+  public static function personalizationObject(array $data = null) {
+    return (new HeaderData($data))->returnPersonalizationObject();
   }
 
   /**
@@ -255,13 +233,15 @@ class HeaderData {
    *
    * @param string|array $key
    *   Key for the header, or array of keys.
+   * @param array $data (optional)
+   *   The header data to parse. Defaults to $_SERVER.
    *
    * @return array
    *   Vary header array, based on header data.
    *
    * @see returnVaryHeader()
    */
-  public static function varyHeader($key): array {
-    return self::getInstance()->returnVaryHeader($key);
+  public static function varyHeader($key, array $data = null): array {
+    return (new HeaderData($data))->returnVaryHeader($key);
   }
 }

--- a/src/HeaderData.php
+++ b/src/HeaderData.php
@@ -17,6 +17,13 @@ class HeaderData {
   private $headers;
 
   /**
+   * The static header data used for the global function calls.
+   *
+   * @var headerData
+   */
+  private static $headerData;
+
+  /**
    * Constructor.
    *
    * @param array $headerData (optional)
@@ -180,4 +187,81 @@ class HeaderData {
     return ['vary' => $vary_header_array];
   }
 
+  /**
+   * Get the singleton instance for the global functions API.
+   */
+  private static function getInstance(): HeaderData {
+    if (self::$headerData == null) {
+      self::$headerData = new HeaderData();
+    }
+ 
+    return self::$headerData;
+  }
+
+  /**
+   * Sets the given header data associated with the global functions.
+   * 
+   * @param $data array (optional)
+   *   The array data to set when reading header data. Defaults to $_SERVER.
+   */
+  public static function setHeaderData(array $data = null): void {
+    self::$headerData = new HeaderData($data);
+  }
+
+  /**
+   * Gets the global header data based on the given key.
+   *
+   * @param string $key
+   *   Key for the header.
+   *
+   * @return string
+   *   Returns header value.
+   *
+   * @see getHeader()
+   */
+  public static function header($key) {
+    return self::getInstance()->getHeader($key);
+  }
+
+  /**
+   * Parses a global header by key using a specified regex.
+   *
+   * @param string $key
+   *   Key for the header.
+   *
+   * @return array|string
+   *   Returns important parts of header string.
+   *
+   * @see parseHeader()
+   */
+  public static function parse($key) {
+    return self::getInstance()->parseHeader($key);
+  }
+
+  /**
+   * Gets the global personalizaition object.
+   *
+   * @return array
+   *   Returns object with data used for personalization.
+   * 
+   * @see returnPersonalizedObject()
+   */
+  public static function personalizationObject() {
+    return self::getInstance()->returnPersonalizationObject();
+  }
+
+  /**
+   * Returns vary header array based on the global data.
+   *
+   * @param string|array $key
+   *   Key for the header, or array of keys.
+   *
+   * @return array
+   *   Vary header array, based on header data.
+   *
+   * @see returnVaryHeader()
+   */
+  public static function varyHeader($key): array {
+    return self::getInstance()->returnVaryHeader($key);
+  }
 }

--- a/tests/HeaderDataTest.php
+++ b/tests/HeaderDataTest.php
@@ -149,5 +149,86 @@ final class HeaderDataTest extends TestCase
     $result = $headerData->returnVaryHeader(['Author' => 'Ray Bradbury']);
     $this->assertEquals($result['vary']['Author'], 'Ray Bradbury');
   }
-}
 
+  /**
+   * Tests the global HeaderData::header() function.
+   * 
+   * @see Pantheon\EI\HeaderData::header()
+   * 
+   * @group headerdata
+   */
+  public function testGlobalHeader() {
+    // Initialize both the global and an instance as the same input.
+    $input = [
+      'IGNORED_ENTRY' => 'Completely ignored entry',
+      'HTTP_SHOULD_BE_FOUND' => 'Should be found',
+    ];
+    HeaderData::setHeaderData($input);
+
+    $this->assertIsString(HeaderData::header('Should-Be-Found'), 'HeaderData::header() should return a string');
+    $this->assertEquals('Should be found', HeaderData::header('Should-Be-Found'));
+  }
+
+  /**
+   * Tests the global HeaderData::parse() function.
+   * 
+   * @see Pantheon\EI\HeaderData::parse()
+   * 
+   * @group headerdata
+   */
+  public function testGlobalParse() {
+    // Initialize both the global and an instance as the same input.
+    $input = [
+      'HTTP_AUDIENCE' => 'Parents|Children||Age:47|Name:RobLoach|Name:StevePersch|Name:AnnaMykhailova',
+      'HTTP_IGNORED' => 'HTTP Ignored Entry',
+      'IGNORED_ENTRY' => 'Completely ignored entry',
+    ];
+    HeaderData::setHeaderData($input);
+
+    // parse()
+    $audience = HeaderData::parse('Audience');
+    $this->assertArrayHasKey('Age', $audience);
+    $this->assertEquals(47, $audience['Age']);
+  }
+
+  /**
+   * Tests the global HeaderData::personalizationObject() function.
+   * 
+   * @see Pantheon\EI\HeaderData::personalizationObject()
+   * 
+   * @group headerdata
+   */
+  public function testGlobalPersonalizationObject() {
+    $input = [
+      'HTTP_ROLE' => 'Administrator',
+    ];
+    HeaderData::setHeaderData($input);
+
+    // personalizationObject()
+    $personalizationObject = HeaderData::personalizationObject();
+    $this->assertArrayHasKey('Role', $personalizationObject);
+    $this->assertEquals('Administrator', $personalizationObject['Role']);
+  }
+
+  /**
+   * Tests the global HeaderData::varyHeader() function.
+   * 
+   * @see Pantheon\EI\HeaderData::varyHeader()
+   * 
+   * @group headerdata
+   */
+  public function testGlobalVaryHeader(): void {
+    // Initialize both the global and an instance as the same input.
+    $input = [
+      'HTTP_IGNORED' => 'HTTP Ignored Entry',
+      'IGNORED_ENTRY' => 'Completely ignored entry',
+      'HTTP_SHOULD_BE_FOUND' => 'Should be found',
+      'HTTP_VARY' => 'Something, Wicked, This, Way',
+    ];
+    HeaderData::setHeaderData($input);
+
+    $varyHeader = HeaderData::varyHeader('Comes');
+    $this->assertArrayHasKey('vary', $varyHeader);
+    $this->assertEquals($varyHeader['vary'], ['Something', 'Wicked', 'This', 'Way', 'Comes']);
+  }
+}

--- a/tests/HeaderDataTest.php
+++ b/tests/HeaderDataTest.php
@@ -163,10 +163,10 @@ final class HeaderDataTest extends TestCase
       'IGNORED_ENTRY' => 'Completely ignored entry',
       'HTTP_SHOULD_BE_FOUND' => 'Should be found',
     ];
-    HeaderData::setHeaderData($input);
 
-    $this->assertIsString(HeaderData::header('Should-Be-Found'), 'HeaderData::header() should return a string');
-    $this->assertEquals('Should be found', HeaderData::header('Should-Be-Found'));
+    $result = HeaderData::header('Should-Be-Found', $input);
+    $this->assertIsString($result, 'HeaderData::header() should return a string');
+    $this->assertEquals('Should be found', $result);
   }
 
   /**
@@ -183,9 +183,8 @@ final class HeaderDataTest extends TestCase
       'HTTP_IGNORED' => 'HTTP Ignored Entry',
       'IGNORED_ENTRY' => 'Completely ignored entry',
     ];
-    HeaderData::setHeaderData($input);
 
-    $audience = HeaderData::parse('Audience');
+    $audience = HeaderData::parse('Audience', $input);
     $this->assertArrayHasKey('Age', $audience);
     $this->assertEquals(47, $audience['Age']);
   }
@@ -201,9 +200,8 @@ final class HeaderDataTest extends TestCase
     $input = [
       'HTTP_ROLE' => 'Administrator',
     ];
-    HeaderData::setHeaderData($input);
 
-    $personalizationObject = HeaderData::personalizationObject();
+    $personalizationObject = HeaderData::personalizationObject($input);
     $this->assertArrayHasKey('Role', $personalizationObject);
     $this->assertEquals('Administrator', $personalizationObject['Role']);
   }
@@ -223,9 +221,8 @@ final class HeaderDataTest extends TestCase
       'HTTP_SHOULD_BE_FOUND' => 'Should be found',
       'HTTP_VARY' => 'Something, Wicked, This, Way',
     ];
-    HeaderData::setHeaderData($input);
 
-    $varyHeader = HeaderData::varyHeader('Comes');
+    $varyHeader = HeaderData::varyHeader('Comes', $input);
     $this->assertArrayHasKey('vary', $varyHeader);
     $this->assertEquals($varyHeader['vary'], ['Something', 'Wicked', 'This', 'Way', 'Comes']);
   }

--- a/tests/HeaderDataTest.php
+++ b/tests/HeaderDataTest.php
@@ -185,7 +185,6 @@ final class HeaderDataTest extends TestCase
     ];
     HeaderData::setHeaderData($input);
 
-    // parse()
     $audience = HeaderData::parse('Audience');
     $this->assertArrayHasKey('Age', $audience);
     $this->assertEquals(47, $audience['Age']);
@@ -204,7 +203,6 @@ final class HeaderDataTest extends TestCase
     ];
     HeaderData::setHeaderData($input);
 
-    // personalizationObject()
     $personalizationObject = HeaderData::personalizationObject();
     $this->assertArrayHasKey('Role', $personalizationObject);
     $this->assertEquals('Administrator', $personalizationObject['Role']);


### PR DESCRIPTION
This change introduces global static methods to mirror the instance methods. Allows for using the API without instantiating an object.

https://kalamuna.atlassian.net/jira/software/c/projects/CP/boards/140?modal=detail&selectedIssue=CP-97