### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,14 @@ Returns vary header array, based on header data.
 composer install
 composer test
 ```
+
+## Default branch name
+
+The default branch name is `main`. This has changed since the project was created. If your local environment is still using `master` as the default branch name, you may update by running the following commands:
+
+```bash
+git branch -m master <BRANCH>
+git fetch origin
+git branch -u origin/<BRANCH> <BRANCH>
+git remote set-head origin -a
+```


### PR DESCRIPTION
Adds the local branch renaming steps to the README. This shows up on the GitHub repository if you haven't seen it yet, but keeping it in the README will increase visibility. Eventually, though, this won't matter and we can just remove because it will always have been `main`.

Closes #5 