### PR TITLE
Update linting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     }
   },
   "scripts": {
-    "cbf": "vendor/bin/phpcbf --standard=PSR2 src",
-    "lint": "vendor/bin/phpcs --standard=PSR2 src",
+    "cbf": "vendor/bin/phpcbf -s --standard=PSR2 src",
+    "lint": "vendor/bin/phpcs -s --standard=PSR2 src",
     "test": "vendor/bin/phpunit -c phpunit.xml"
   },
   "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,10 @@
     }
   },
   "scripts": {
-    "cbf": "vendor/bin/phpcbf -s --standard=PSR2 src",
-    "lint": "vendor/bin/phpcs -s --standard=PSR2 src",
+    "cbf": "vendor/bin/phpcbf -s --standard=phpcs.ruleset.xml --extensions=php ./src/",
+    "lint:php": "find src/ -name '*.php' -exec php -l {} \\;",
+    "lint:phpcs": "vendor/bin/phpcs -s --standard=phpcs.ruleset.xml --extensions=php ./src/",
+    "lint": "composer lint:php && composer lint:phpcs",
     "test": "vendor/bin/phpunit -c phpunit.xml"
   },
   "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "cbf": "vendor/bin/phpcbf -s --standard=phpcs.ruleset.xml --extensions=php ./src/",
+    "lint:phpcbf": "vendor/bin/phpcbf -s --standard=phpcs.ruleset.xml --extensions=php ./src/",
     "lint:php": "find src/ -name '*.php' -exec php -l {} \\;",
     "lint:phpcs": "vendor/bin/phpcs -s --standard=phpcs.ruleset.xml --extensions=php ./src/",
     "lint": "composer lint:php && composer lint:phpcs",

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset>
+	<!-- Path to strip from the front of file paths inside reports (displays shorter paths) -->
+	<arg name="basepath" value="."/>
+
+	<!-- Set standard to PSR2. -->
+	<rule ref="PSR2">
+		<!-- Ignore the brace on a new line sniff. -->
+		<exclude name="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine"/>
+		<exclude name="PSR2.Classes.ClassDeclaration.OpenBraceNewLine"/>
+	</rule>
+</ruleset>

--- a/src/HeaderData.php
+++ b/src/HeaderData.php
@@ -7,8 +7,7 @@ namespace Pantheon\EI;
 /**
  * A class to handle smart content delivery network for users.
  */
-class HeaderData
-{
+class HeaderData {
 
   /**
    * Header data.
@@ -25,8 +24,7 @@ class HeaderData
    *
    * @see https://www.php.net/manual/en/reserved.variables.server.php
    */
-    public function __construct(array $headerData = null)
-    {
+    public function __construct(array $headerData = null) {
         $this->headers = $this->getRequestHeaders($headerData);
     }
 
@@ -38,8 +36,7 @@ class HeaderData
    *
    * @see https://www.php.net/manual/en/reserved.variables.server.php
    */
-    private function getRequestHeaders(array $headerData = null): array
-    {
+    private function getRequestHeaders(array $headerData = null): array {
         if (is_null($headerData)) {
             $headerData = $_SERVER;
         }
@@ -64,8 +61,7 @@ class HeaderData
    * @return string
    *   Returns header value.
    */
-    public function getHeader($key): string
-    {
+    public function getHeader($key): string {
         return !empty($this->headers[$key]) ? $this->headers[$key] : '';
     }
 
@@ -78,8 +74,7 @@ class HeaderData
    * @return array|string
    *   Returns important parts of header string.
    */
-    public function parseHeader($key)
-    {
+    public function parseHeader($key) {
       // Get specified header.
         $header = $this->getHeader($key);
 
@@ -135,8 +130,7 @@ class HeaderData
    * @return array
    *   Returns object with data used for personalization.
    */
-    public function returnPersonalizationObject(): array
-    {
+    public function returnPersonalizationObject(): array {
         $p_obj = [];
 
         $header_keys = [
@@ -167,8 +161,7 @@ class HeaderData
    * @return array
    *   Vary header array, based on header data.
    */
-    public function returnVaryHeader($key): array
-    {
+    public function returnVaryHeader($key): array {
       // Get current vary data if it exists, otherwise start with empty array.
         $vary_header = $this->getHeader('Vary');
         $vary_header_array = !empty($vary_header) ? explode(', ', $vary_header) : [];


### PR DESCRIPTION
This PR updates the linting config:

* Adds the `-s` param to `phpcs` and `phpcbf` functions to display the sniff name (makes it easier to exclude)
* Adds a global phpcs ruleset
* Excludes the "brace on a new line" rules 
* Adds a php check to validate that the php executes and does not have any syntax errors