### PR TITLE
[EI-71] Use new headers

### DIFF
--- a/src/HeaderData.php
+++ b/src/HeaderData.php
@@ -104,6 +104,7 @@ class HeaderData {
                     }
                     break;
 
+                // Parse Interest header.
                 case 'Interest':
                   // Decode special characters.
                     $header_decoded = urldecode($header);

--- a/src/HeaderData.php
+++ b/src/HeaderData.php
@@ -83,6 +83,7 @@ class HeaderData {
             switch ($key) {
                 // Parse Audience header.
                 case 'Audience':
+                case 'Audience-Set':
                   // Separate different pairs in header string.
                     $header_parts = explode('|', $header);
 
@@ -103,9 +104,6 @@ class HeaderData {
                     }
                     break;
 
-                // The Audience-Set header should be handled the same as the Interest header for now. If/when this is updated, it will behave more like Audience.
-                case 'Audience-Set':
-                // Parse Interest header.
                 case 'Interest':
                   // Decode special characters.
                     $header_decoded = urldecode($header);

--- a/src/HeaderData.php
+++ b/src/HeaderData.php
@@ -137,6 +137,7 @@ class HeaderData {
 
         $header_keys = [
         'Audience',
+        'Audience-Set',
         'Interest',
         'Role',
         ];

--- a/src/HeaderData.php
+++ b/src/HeaderData.php
@@ -103,6 +103,8 @@ class HeaderData {
                     }
                     break;
 
+                // The Audience-Set header should be handled the same as the Interest header for now. If/when this is updated, it will behave more like Audience.
+                case 'Audience-Set':
                 // Parse Interest header.
                 case 'Interest':
                   // Decode special characters.


### PR DESCRIPTION
This implements the new `audience-set` header type that contains more geo data. ~Keeping as a draft for now because the shape of the data might change.~

Updates the Audience case to handle the `audience-set` header.
![Screen Shot 2022-02-18 at 9 39 56 AM](https://user-images.githubusercontent.com/991511/154725876-997e88cb-5396-4571-959d-773e344b018d.png)

