### PR TITLE
README badge & branch naming updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pantheon Edge Integrations
 
-[![Unsupported](https://img.shields.io/badge/pantheon-unsupported-yellow?logo=pantheon&color=FFDC28&style=for-the-badge)](https://github.com/topics/unsupported?q=org%3Apantheon-systems "Unsupported, e.g. a tool we are actively using internally and are making available, but do not promise to support") ![Build Status](https://github.com/pantheon-systems/pantheon-edge-integrations/actions/workflows/main.yml/badge.svg)
+[![Unsupported](https://img.shields.io/badge/pantheon-unsupported-yellow?logo=pantheon&color=FFDC28)](https://github.com/topics/unsupported?q=org%3Apantheon-systems "Unsupported, e.g. a tool we are actively using internally and are making available, but do not promise to support") ![Build Status](https://github.com/pantheon-systems/pantheon-edge-integrations/actions/workflows/main.yml/badge.svg)
 
 Pantheon Edge Integrations uses header data to provide a personalization object, to be used for personalizing content for each user.
 

--- a/README.md
+++ b/README.md
@@ -25,14 +25,3 @@ Returns vary header array, based on header data.
 composer install
 composer test
 ```
-
-## Default branch name
-
-The default branch name is `main`. This has changed since the project was created. If your local environment is still using `master` as the default branch name, you may update by running the following commands:
-
-```bash
-git branch -m master <BRANCH>
-git fetch origin
-git branch -u origin/<BRANCH> <BRANCH>
-git remote set-head origin -a
-```


### PR DESCRIPTION
Switches the `pantheon unsupported` badge to the standard badge style & removes the `main`/`master` branch naming notes as they are no longer valid and new checkouts of this repo would only ever have had a `main` branch.