### PR TITLE
[EI-218] header changes

### DIFF
--- a/src/HeaderData.php
+++ b/src/HeaderData.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * HeaderData Class
+ *
+ * Handles interactions with headers sent from Fastly to the application.
+ *
+ * @package Pantheon\EI\HeaderData
+ */
 
 declare(strict_types = 1);
 

--- a/src/HeaderData.php
+++ b/src/HeaderData.php
@@ -82,8 +82,9 @@ class HeaderData {
    *   Returns important parts of header string.
    */
     public function parseHeader($key) {
-      // Get specified header.
+        // Get specified header.
         $header = $this->getHeader($key);
+        $parsed_header = in_array($key, [ 'Interest', 'P13n-Interest' ], true)? [] : '';
 
         if (!empty($header)) {
             $parsed_header = [];

--- a/src/HeaderData.php
+++ b/src/HeaderData.php
@@ -90,6 +90,32 @@ class HeaderData {
         if (empty($header)) {
             return $parsed_header;
         }
+
+        // Decode the header.
+        $header_decoded = urldecode($header);
+
+        // Backwards compatibility with Audience and Audience-Set.
+        if (in_array($key, ['Audience','Audience-Set'], true)) {
+            $parsed_header = $this->__deprecatedAudienceHandling($key, $header_decoded);
+            return $parsed_header;
+        }
+
+        // If the header is an interest, or if the value has multiple entries,
+        // allow those entries to be split into an array.
+        if (in_array($key, [ 'Interest', 'P13n-Interest' ], true) ||
+          stripos($header_decoded, '|')
+        ) {
+            $parsed_header = explode('|', $header_decoded);
+            // Trim white space out of values.
+            $parsed_header = array_map('trim', $parsed_header);
+        }
+
+        // If the header is not an interest (e.g. Geo or custom), set the value to the decoded header.
+        if (empty($parsed_header)) {
+            $parsed_header = $header_decoded;
+        }
+
+        return $parsed_header;
     }
 
   /**

--- a/src/HeaderData.php
+++ b/src/HeaderData.php
@@ -169,6 +169,14 @@ class HeaderData {
         $p_obj = [];
 
         $header_keys = [
+        'P13n-Geo-Region',
+        'P13n-Geo-Country-Code',
+        'P13n-Geo-Country-Name',
+        'P13n-Geo-Continent-Code',
+        'P13n-Geo-City',
+        'P13n-Geo-Conn-Type',
+        'P13n-Geo-Conn-Speed',
+        'P13n-Interest',
         'Audience',
         'Audience-Set',
         'Interest',

--- a/src/HeaderData.php
+++ b/src/HeaderData.php
@@ -177,10 +177,10 @@ class HeaderData {
         'P13n-Geo-Conn-Type',
         'P13n-Geo-Conn-Speed',
         'P13n-Interest',
-        'Audience',
-        'Audience-Set',
-        'Interest',
-        'Role',
+        'Audience', // Deprecated.
+        'Audience-Set', // Deprecated.
+        'Interest', // Deprecated.
+        'Role', // Not implemented.
         ];
 
         foreach ($header_keys as $key) {

--- a/src/HeaderData.php
+++ b/src/HeaderData.php
@@ -86,8 +86,10 @@ class HeaderData {
         $header = $this->getHeader($key);
         $parsed_header = in_array($key, [ 'Interest', 'P13n-Interest' ], true)? [] : '';
 
-        if (!empty($header)) {
-            $parsed_header = [];
+        // If the header is empty, bail early.
+        if (empty($header)) {
+            return $parsed_header;
+        }
             switch ($key) {
                 // Parse Audience header.
                 case 'Audience':

--- a/src/HeaderData.php
+++ b/src/HeaderData.php
@@ -90,49 +90,47 @@ class HeaderData {
         if (empty($header)) {
             return $parsed_header;
         }
-            switch ($key) {
-                // Parse Audience header.
-                case 'Audience':
-                case 'Audience-Set':
-                  // Separate different pairs in header string.
-                    $header_parts = explode('|', $header);
+    }
 
-                    foreach ($header_parts as $header_part) {
-                        // Skip if empty.
-                        if (empty($header_part)) {
-                            continue;
-                        }
+  /**
+   * Handles deprecated Audience and Audience-Set headers.
+   * @param string $key The header key. Either 'Audience' or 'Audience-Set'.
+   * @param string $header The header value.
+   * @return array
+   *  Returns an array of audience data.
+   * @deprecated
+   *  This function is deprecated and will be removed in a future release.
+   */
+    public function __deprecatedAudienceHandling(string $key, string $header) : array {
+        $parsed_header = [];
 
-                        // Separate the pair string into key and value.
-                        $header_pair = explode(':', $header_part);
-                        if (count($header_pair) >= 2) {
-                            $parsed_header[$header_pair[0]] = $header_pair[1];
-                        } else {
-                            // If string isn't formatted as a pair, just set string.
-                            $parsed_header[$key][] = $header_part;
-                        }
-                    }
-                    break;
-
-                // Parse Interest header.
-                case 'Interest':
-                  // Decode special characters.
-                    $header_decoded = urldecode($header);
-
-                  // Split header value into an array.
-                    $parsed_header = explode('|', $header_decoded);
-                    break;
-
-                // By default, just return header.
-                default:
-                    $parsed_header = $header;
-                    break;
-            }
-
-            return $parsed_header;
+        // If we're dealing with an Audience header, we need to add it to an array.
+        if ($key === 'Audience') {
+            $_headers = [$header];
         }
 
-        return [];
+        // Split the header data at the | character.
+        $_headers = explode('|', $header);
+
+        // Loop through each header.
+        foreach ($_headers as $i => $header_part) {
+            // If the header is empty, bail early.
+            if (empty($header_part)) {
+                continue;
+            }
+
+            // Split at the : character.
+            $header_pair = explode(':', $header_part);
+            // If we actually have a header pair, map the key and value.
+            // Otherwise, just return the value for the passed key.
+            if (count($header_pair) >= 2) {
+                $parsed_header[$header_pair[0]] = $header_pair[1];
+            } else {
+                $parsed_header[$key] = $header_part;
+            }
+        }
+
+        return $parsed_header;
     }
 
   /**

--- a/tests/HeaderDataTest.php
+++ b/tests/HeaderDataTest.php
@@ -159,13 +159,17 @@ final class HeaderDataTest extends TestCase
   public function testReturnPersonalizationObject(): void {
     $headerData = new HeaderData($this->p13n_input);
     $result = $headerData->returnPersonalizationObject();
-
-    $this->assertEquals($result['Audience']['geo'], 'US');
+    $this->assertEquals($result['P13n-Geo-Country-Code'], 'US');
+    $this->assertEquals($result['P13n-Geo-Country-Name'], 'united states');
+    $this->assertEquals($result['P13n-Geo-City'], 'salt lake city');
+    $this->assertEquals($result['P13n-Geo-Region'], 'UT');
+    $this->assertEquals($result['P13n-Geo-Continent-Code'], 'NA');
+    $this->assertEquals($result['P13n-Geo-Conn-Type'], 'wifi');
+    $this->assertEquals($result['P13n-Geo-Conn-Speed'], 'broadband');
+    $this->assertIsArray($result['P13n-Interest']);
+    $this->assertContains('Edith Clark',$result['P13n-Interest']);
     $this->assertEquals($result['Role'], 'Administrator');
     $this->assertArrayNotHasKey('Ignored', $result);
-    // Test the first and last things in the Audience Set array. If we have both, we can assume everything in the middle matches as well.
-    $this->assertEquals($result['Audience-Set']['country'], 'US');
-    $this->assertEquals($result['Audience-Set']['conn-type'], 'wired');
   }
 
   /**

--- a/tests/HeaderDataTest.php
+++ b/tests/HeaderDataTest.php
@@ -125,6 +125,15 @@ final class HeaderDataTest extends TestCase
       'With A Percent'
     ];
     $this->assertEquals($interest, $expected);
+    $p13n_interest = $headerData->parseHeader('P13n-Interest');
+    $this->assertEquals($p13n_interest, [
+      'Marie Curie',
+      'Jane Goodall',
+      'Edith Clark',
+      '',
+      'For Science!',
+      'With A Percent'
+    ]);
 
     // User Agent
     $this->assertEquals($headerData->parseHeader('User-Agent'), 'Should just return the value');

--- a/tests/HeaderDataTest.php
+++ b/tests/HeaderDataTest.php
@@ -229,12 +229,14 @@ final class HeaderDataTest extends TestCase
     // Initialize both the global and an instance as the same input.
     $input = $this->p13n_input;
 
-    $audience = HeaderData::parse('Audience', $input);
-    $audienceSet = HeaderData::parse('Audience-Set', $input);
-    $this->assertArrayHasKey('Age', $audience);
-    $this->assertEquals(47, $audience['Age']);
-    $this->assertArrayHasKey( 'region', $audienceSet );
-    $this->assertEquals( 'UT', $audienceSet['region'] );
+    $country_code = HeaderData::parse('P13n-Geo-Country-Code', $input);
+    $city = HeaderData::parse('P13n-Geo-City', $input);
+    $region = HeaderData::parse('P13n-Geo-Region', $input);
+    $interest = HeaderData::parse('P13n-Interest', $input);
+    $this->assertEquals('US', $country_code);
+    $this->assertEquals('salt lake city', $city);
+    $this->assertEquals( 'UT', $region );
+    $this->assertContains( 'Jane Goodall', $interest );
   }
 
   /**

--- a/tests/HeaderDataTest.php
+++ b/tests/HeaderDataTest.php
@@ -18,6 +18,25 @@ use Pantheon\EI\HeaderData;
  */
 final class HeaderDataTest extends TestCase
 {
+
+  private $p13n_input = [
+    'HTTP_P13N_GEO_COUNTRY_CODE' => 'US',
+    'HTTP_P13N_GEO_COUNTRY_NAME' => 'united states',
+    'HTTP_P13N_GEO_CITY' => 'salt lake city',
+    'HTTP_P13N_GEO_REGION' => 'UT',
+    'HTTP_P13N_GEO_CONTINENT_CODE' => 'NA',
+    'HTTP_P13N_GEO_CONN_TYPE' => 'wifi',
+    'HTTP_P13N_GEO_CONN_SPEED' => 'broadband',
+    'HTTP_P13N_Interest' => 'Marie Curie|Jane Goodall|Edith Clark||For Science!|With A Percent%20',
+    'HTTP_USER_AGENT' => 'Should just return the value',
+    'HTTP_ROLE' => 'Administrator',
+    'HTTP_INTEREST' => 'Carl Sagan|Richard Feynman||For Science!|With A Percent%20',
+    'HTTP_AUDIENCE' => 'geo:us',
+    'HTTP_AUDIENCE_SET' => 'country:us|city:salt lake city|region:UT|continent:NA|conn_type:wifi|conn_speed:broadband',
+    'HTTP_IGNORED' => 'HTTP Ignored Entry',
+    'IGNORED_ENTRY' => 'Completely ignored entry'
+  ];
+
   /**
    * Tests the HeaderData constructor.
    *

--- a/tests/HeaderDataTest.php
+++ b/tests/HeaderDataTest.php
@@ -89,8 +89,8 @@ final class HeaderDataTest extends TestCase
 
     // When a header doesn't exist.
     $keyNotFound = $headerData->parseHeader('header key not found');
-    $this->assertEmpty($keyNotFound, 'Expected to return an empty array');
-    $this->assertIsArray($keyNotFound, 'Should be an array');
+    $this->assertEmpty($keyNotFound, 'Expected to return an empty string');
+    $this->assertIsString($keyNotFound, 'Should be a string');
 
     // Audience
     $audience = $headerData->parseHeader('Audience');

--- a/tests/HeaderDataTest.php
+++ b/tests/HeaderDataTest.php
@@ -92,22 +92,28 @@ final class HeaderDataTest extends TestCase
     $this->assertEmpty($keyNotFound, 'Expected to return an empty string');
     $this->assertIsString($keyNotFound, 'Should be a string');
 
-    // Audience
-    $audience = $headerData->parseHeader('Audience');
-    $this->assertIsArray($audience['Audience']);
-    $this->assertEquals($audience['Audience'][1], 'Children');
-    $this->assertEquals($audience['Name'], 'AnnaMykhailova'); // Take the last entry.
-    $this->assertEquals($audience['Age'], 47);
-
-    // Audience Set
-    $audienceSet = $headerData->parseHeader('Audience-Set');
-    $this->assertIsArray($audienceSet);
-    $this->assertEquals($audienceSet['country'], 'US');
-    $this->assertEquals($audienceSet['city'], 'Salt Lake City');
-    $this->assertEquals($audienceSet['region'], 'UT');
-    $this->assertEquals($audienceSet['continent'], 'NA');
-    $this->assertEquals($audienceSet['conn-speed'], 'broadband');
-    $this->assertEquals($audienceSet['conn-type'], 'wired');
+    // Geolocation.
+    $country_code = $headerData->parseHeader('P13n-Geo-Country-Code');
+    $this->assertIsString($country_code, 'Should be a string');
+    $this->assertEquals($country_code, 'US');
+    $country_name = $headerData->parseHeader('P13n-Geo-Country-Name');
+    $this->assertIsString($country_name, 'Should be a string');
+    $this->assertEquals($country_name, 'united states');
+    $city = $headerData->parseHeader('P13n-Geo-City');
+    $this->assertIsString($city, 'Should be a string');
+    $this->assertEquals($city, 'salt lake city');
+    $region = $headerData->parseHeader('P13n-Geo-Region');
+    $this->assertIsString($region, 'Should be a string');
+    $this->assertEquals($region, 'UT');
+    $continent_code = $headerData->parseHeader('P13n-Geo-Continent-Code');
+    $this->assertIsString($continent_code, 'Should be a string');
+    $this->assertEquals($continent_code, 'NA');
+    $conn_type = $headerData->parseHeader('P13n-Geo-Conn-Type');
+    $this->assertIsString($conn_type, 'Should be a string');
+    $this->assertEquals($conn_type, 'wifi');
+    $conn_speed = $headerData->parseHeader('P13n-Geo-Conn-Speed');
+    $this->assertIsString($conn_speed, 'Should be a string');
+    $this->assertEquals($conn_speed, 'broadband');
 
     // Interest
     $interest = $headerData->parseHeader('Interest');

--- a/tests/HeaderDataTest.php
+++ b/tests/HeaderDataTest.php
@@ -85,15 +85,7 @@ final class HeaderDataTest extends TestCase
    * @group headerdata
    */
   public function testParseHeader(): void {
-    // The Audience and Interest entries are parsed into arrays.
-    $input = [
-      'HTTP_AUDIENCE' => 'Parents|Children||Age:47|Name:RobLoach|Name:StevePersch|Name:AnnaMykhailova',
-      'HTTP_AUDIENCE_SET' => 'country:US|city:Salt Lake City|region:UT|continent:NA|conn-speed:broadband|conn-type:wired',
-      'HTTP_USER_AGENT' => 'Should just return the value',
-      'IGNORED TEST' => 'Should return an empty array',
-      'HTTP_INTEREST' => 'Carl Sagan|Richard Feynman||For Science!|With%20A Percent20',
-    ];
-    $headerData = new HeaderData($input);
+    $headerData = new HeaderData($this->p13n_input);
 
     // When a header doesn't exist.
     $keyNotFound = $headerData->parseHeader('header key not found');
@@ -138,15 +130,7 @@ final class HeaderDataTest extends TestCase
    * @group headerdata
    */
   public function testReturnPersonalizationObject(): void {
-    $input = [
-      'HTTP_AUDIENCE' => 'geo:US',
-      'HTTP_AUDIENCE_SET' => 'country:US|city:Salt Lake City|region:UT|continent:NA|conn-speed:broadband|conn-type:wired',
-      'HTTP_ROLE' => 'Administrator',
-      'HTTP_INTEREST' => 'Carl Sagan|Richard Feynman',
-      'HTTP_IGNORED' => 'HTTP Ignored Entry',
-      'IGNORED_ENTRY' => 'Completely ignored entry'
-    ];
-    $headerData = new HeaderData($input);
+    $headerData = new HeaderData($this->p13n_input);
     $result = $headerData->returnPersonalizationObject();
 
     $this->assertEquals($result['Audience']['geo'], 'US');
@@ -212,12 +196,7 @@ final class HeaderDataTest extends TestCase
    */
   public function testGlobalParse() {
     // Initialize both the global and an instance as the same input.
-    $input = [
-      'HTTP_AUDIENCE' => 'Parents|Children||Age:47|Name:RobLoach|Name:StevePersch|Name:AnnaMykhailova',
-      'HTTP_AUDIENCE_SET' => 'country:US|city:Salt Lake City|region:UT|continent:NA|conn-speed:broadband|conn-type:wired',
-      'HTTP_IGNORED' => 'HTTP Ignored Entry',
-      'IGNORED_ENTRY' => 'Completely ignored entry',
-    ];
+    $input = $this->p13n_input;
 
     $audience = HeaderData::parse('Audience', $input);
     $audienceSet = HeaderData::parse('Audience-Set', $input);

--- a/tests/HeaderDataTest.php
+++ b/tests/HeaderDataTest.php
@@ -122,7 +122,7 @@ final class HeaderDataTest extends TestCase
       'Richard Feynman',
       '',
       'For Science!',
-      'With A Percent20'
+      'With A Percent'
     ];
     $this->assertEquals($interest, $expected);
 

--- a/tests/HeaderDataTest.php
+++ b/tests/HeaderDataTest.php
@@ -137,6 +137,18 @@ final class HeaderDataTest extends TestCase
 
     // User Agent
     $this->assertEquals($headerData->parseHeader('User-Agent'), 'Should just return the value');
+
+    // Backcompat.
+    $audience = $headerData->parseHeader('Audience');
+    $this->assertEquals($audience['geo'], 'us');
+
+    $audience_set = $headerData->parseHeader('Audience-Set');
+    $this->assertEquals($audience_set['country'], 'us');
+    $this->assertEquals($audience_set['city'], 'salt lake city');
+    $this->assertEquals($audience_set['region'], 'UT');
+    $this->assertEquals($audience_set['continent'], 'NA');
+    $this->assertEquals($audience_set['conn_type'], 'wifi');
+    $this->assertEquals($audience_set['conn_speed'], 'broadband');
   }
 
   /**


### PR DESCRIPTION
This PR is part of a _breaking change_ (will be part of a new 1.1 release to maintain current version stability) that updates the headers we are receiving and using from Fastly.

`Audience` and `Audience-Set` headers will be deprecated, and handling for those headers has been moved to a new function that's marked as `deprecated` (`__deprecatedAudienceHandling()`). Taken out of the equation, handling for all the other headers can be done in a much more straightforward way without the need for a PHP switch statement. Additionally, we can normalize (`urldecode`) the data from all headers we're receiving, not just the expected ones and, as such, we're able to trim whitespace if required.

The new headers are all prefixed `P13n-`/`P13n-Geo-` and individual headers are passed for each discrete piece of data, so varying on geo becomes much easier and robust.

All the tests have been updated to check both the current (deprecated) headers and the new headers and (anecdotally) tested locally and on https://dev-wp.ei-squad.ps-pantheon.com/ to validate that there is nothing fatally breaking downstream.